### PR TITLE
Update commands.js to correct the output of faucet

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -38,12 +38,8 @@ commands.set('deposit', {
             const blockHash = result.status.asInBlock;
             const link = 'https://testnet.avail.tools/#/explorer/query/' + blockHash;
             interaction.followUp({
-              content: `Status: Complete
-            Amount:  1 AVL
-            Txn Hash: ${result.txHash}
-            Block Hash: ${blockHash}
-            🌐 ${hyperlink('View in explorer', link)}`
-            });
+              content: `Status: Complete\nAmount:  1 AVL\nTxn Hash: ${result.txHash}\nBlock Hash: ${blockHash}\n🌐 ${hyperlink('View in explorer', link)}`
+            });            
           }
         }
       });


### PR DESCRIPTION
There were tab spaces for every line except the first line when the faucet successfully sends test tokens. I just add some `\n` to the `commands.js` file to fix it.

**Before:**
![image](https://github.com/availproject/faucet-bot/assets/44838743/7950216a-93ea-44a1-a923-5b433abcd32e)

**After:**
![image](https://github.com/availproject/faucet-bot/assets/44838743/59922f13-deec-48b8-bed3-71c6d9e2abdb)
